### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "azureretailprices-exporter"
-version = "0.1.0"
+version = "0.2.0"
 description = "Export Azure Retail Prices as JSON and convert them to CSV"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `pyproject.toml` version from `0.1.0` to `0.2.0` ahead of the v0.2.0 release.

This release marks the first versioned code release, incorporating:
- Full dependency update (19 packages)
- API URL bug fix
- Session reuse performance improvement  
- Code quality and documentation improvements from PR #98