### PR TITLE
fix: replace retired VS Code Marketplace badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,6 @@ Use the exported Azure pricing CSV files with AI assistants like GitHub Copilot,
 
 **Example**: *"Create a PivotTable showing Azure VM prices by region, sorted by cost"*
 
-[![VS Code Extension](https://img.shields.io/visual-studio-marketplace/v/sbroenne.excel-mcp)](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)
+[![VS Code Extension](https://vsmarketplacebadges.dev/version-short/sbroenne.excel-mcp.svg)](https://marketplace.visualstudio.com/items?itemName=sbroenne.excel-mcp)
 
 [Learn more →](https://github.com/sbroenne/mcp-server-excel/)


### PR DESCRIPTION
## Problem

The related-project `VS Code Extension` badge (linking to the Excel MCP server) renders **"retired badge"**. shields.io retired its `visual-studio-marketplace/v/` endpoint.

## Fix

Switch to [vsmarketplacebadges.dev](https://vsmarketplacebadges.dev), which reports the live version (currently `v1.8.70` for `sbroenne.excel-mcp`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>